### PR TITLE
fire and forget option

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,8 @@ function createXHR(options, callback) {
     }
 
     options = options || {}
-    callback = callback || noop
+    if(options.fireAndForget)
+      callback = callback || noop
     callback = once(callback)
 
     var xhr = options.xhr || null


### PR DESCRIPTION
when the fire and forget option is true or at least not left undefined, then the constructor could be invoked without an error if you elect not to pass its callback function. 