### PR TITLE
Edgecases for v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ function createXHR(options, callback) {
     
     function errorFunc(evt) {
         clearTimeout(timeoutTimer)
-        if(! evt instanceof Error){
-            evt = new Error(""+evt)
+        if(!(evt instanceof Error)){
+            evt = new Error("" + (evt || "unknown") )
         }
         evt.statusCode = 0
         callback(evt, failureResponse)

--- a/index.js
+++ b/index.js
@@ -85,7 +85,9 @@ function createXHR(options, callback) {
     }
 
     options = options || {}
-    callback = callback || noop
+    if(typeof callback === "undefined"){
+        throw new Error("callback argument missing")
+    }
     callback = once(callback)
 
     var xhr = options.xhr || null

--- a/test/index.js
+++ b/test/index.js
@@ -102,3 +102,22 @@ test("XDR usage (run on IE8 or 9)", function (assert) {
     }
     assert.end()
 })
+
+test("handles errorFunc call with no arguments provided", function (assert) {
+    var req = xhr({}, function (err) {
+        assert.ok(err instanceof Error, "callback should get an error")
+        assert.equal(err.message, "unknown", "error message should say 'unknown'")
+    })
+    assert.doesNotThrow(function () {
+        req.onerror()
+    }, "should not throw when error handler called without arguments")
+    assert.end()
+
+})
+
+test("constructs and calls callback without throwing", function (assert) {
+    assert.throws(function () {
+        xhr({})
+    }, "callback is not optional")
+    assert.end()
+})


### PR DESCRIPTION
- explicitly requires a callback now (since we didn't arrive at a conclusion how to make it optional, this can change later)
- fixed incorrect instanceof test (problem seems to have only affected old IEs)
- added tests covering both