### PR TITLE
Add 'send' option to control whether the request is immediately sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Specify whether user credentials are to be included in a cross-origin
 A wildcard `*` cannot be used in the `Access-Control-Allow-Origin` header when `withCredentials` is true. 
     The header needs to specify your origin explicitly or browser will abort the request.
     
+### `options.send`
+
+Specify whether the request should be sent immediately. Defaults to true.
 
 ## MIT Licenced
 

--- a/index.js
+++ b/index.js
@@ -159,7 +159,9 @@ function createXHR(options, callback) {
         options.beforeSend(xhr)
     }
 
-    xhr.send(body)
+    if (!("send" in options) || options.send) {
+      xhr.send(body)
+    }
 
     return xhr
 


### PR DESCRIPTION
In some cases, I want to keep the XMLHttpRequest object around before actually sending it. This patch adds an option for this.