### PR TITLE
Loose once module version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "global": "~4.3.0",
-    "once": "~1.1.1",
+    "once": "^1.1.1",
     "parse-headers": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`once` has quite stable version increase, so loose the version constraint
https://github.com/isaacs/once 