### PR TITLE
Allow global configuration of request constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ Determines the data type of the `response`. Sets [`xhr.responseType`][11]. For e
 
 Pass an `XMLHttpRequest` object (or something that acts like one) to use instead of constructing a new one using the `XMLHttpRequest` or `XDomainRequest` constructors. Useful for testing.
 
+## Mocking Requests
+You can override the constructor used to create new requests for testing. When you're making a new request:
+
+```js
+xhr({ xhr: new MockXMLHttpRequest() })
+```
+
+or you can override the constructors used to create requests at the module level:
+
+```js
+xhr.XMLHttpRequest = MockXMLHttpRequest
+xhr.XDomainRequest = MockXDomainRequest
+```
+
 ## MIT Licenced
 
   [1]: http://xhr.spec.whatwg.org/#the-send()-method

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ var once = require("once")
 var parseHeaders = require("parse-headers")
 
 
-var XHR = window.XMLHttpRequest || noop
-var XDR = "withCredentials" in (new XHR()) ? XHR : window.XDomainRequest
 
 module.exports = createXHR
+createXHR.XMLHttpRequest = window.XMLHttpRequest || noop
+createXHR.XDomainRequest = "withCredentials" in (new createXHR.XMLHttpRequest()) ? createXHR.XMLHttpRequest : window.XDomainRequest
 
 function createXHR(options, callback) {
     function readystatechange() {
@@ -94,9 +94,9 @@ function createXHR(options, callback) {
 
     if (!xhr) {
         if (options.cors || options.useXDR) {
-            xhr = new XDR()
+            xhr = new createXHR.XDomainRequest()
         }else{
-            xhr = new XHR()
+            xhr = new createXHR.XMLHttpRequest()
         }
     }
 
@@ -166,6 +166,5 @@ function createXHR(options, callback) {
 
 
 }
-
 
 function noop() {}

--- a/test/index.js
+++ b/test/index.js
@@ -140,3 +140,25 @@ test("constructs and calls callback without throwing", function (assert) {
     }, "callback is not optional")
     assert.end()
 })
+
+test("XHR can be overridden", function (assert) {
+  var xhrs = 0
+  var noop = function () {}
+  var fakeXHR = function () {
+    xhrs++
+    this.open = this.send = noop
+  }
+  var xdrs = 0
+  var fakeXDR = function () {
+    xdrs++
+    this.open = this.send = noop
+  }
+  xhr.XMLHttpRequest = fakeXHR
+  xhr({}, function () {})
+  assert.equal(xhrs, 1, "created the custom XHR")
+
+  xhr.XDomainRequest = fakeXDR
+  xhr({ useXDR: true }, function () {});
+  assert.equal(xdrs, 1, "created the custom XDR")
+  assert.end()
+})


### PR DESCRIPTION
Fixes #60. Add a new method to the module object to override the constructors for XMLHttpRequest and XDomainRequest. Allows simpler integration with request mocking libraries like sinon.