### PR TITLE
Confirm browser support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,14 @@ module.exports = createXHR
 createXHR.XMLHttpRequest = window.XMLHttpRequest || noop
 createXHR.XDomainRequest = "withCredentials" in (new createXHR.XMLHttpRequest()) ? createXHR.XMLHttpRequest : window.XDomainRequest
 
+
+function isEmpty(obj){
+    for(var i in obj){
+        if(obj.hasOwnProperty(i)) return false
+    }
+    return true
+}
+
 function createXHR(options, callback) {
     function readystatechange() {
         if (xhr.readyState === 4) {
@@ -55,6 +63,7 @@ function createXHR(options, callback) {
 
     // will load the data & process the response in a special response object
     function loadFunc() {
+        if (aborted) return
         var status
         clearTimeout(timeoutTimer)
         if(options.useXDR && xhr.status===undefined) {
@@ -106,6 +115,7 @@ function createXHR(options, callback) {
     }
 
     var key
+    var aborted
     var uri = xhr.url = options.uri || options.url
     var method = xhr.method = options.method || "GET"
     var body = options.body || options.data
@@ -142,6 +152,7 @@ function createXHR(options, callback) {
     if (!sync && options.timeout > 0 ) {
         timeoutTimer = setTimeout(function(){
             xhr.abort("timeout")
+            aborted=true//IE9 may still call readystatechange
         }, options.timeout+2 )
     }
 
@@ -151,7 +162,7 @@ function createXHR(options, callback) {
                 xhr.setRequestHeader(key, headers[key])
             }
         }
-    } else if (options.headers) {
+    } else if (options.headers && !isEmpty(options.headers)) {
         throw new Error("Headers cannot be set on an XDomainRequest object")
     }
 

--- a/index.js
+++ b/index.js
@@ -151,9 +151,10 @@ function createXHR(options, callback) {
     // both npm's request and jquery 1.x use this kind of timeout, so this is being consistent
     if (!sync && options.timeout > 0 ) {
         timeoutTimer = setTimeout(function(){
-            xhr.abort("timeout")
             aborted=true//IE9 may still call readystatechange
-        }, options.timeout+2 )
+            xhr.abort("timeout")
+            errorFunc();
+        }, options.timeout )
     }
 
     if (xhr.setRequestHeader) {

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ test("[func] Returns http error responses like npm's request (cross-domain)", fu
 test("[func] Times out to an error ", function (assert) {
     xhr({
         timeout: 1,
-        uri: "/should-take-a-bit-to-parse?" + (new Array(300)).join("cachebreaker=" + Math.random().toFixed(5) + "&")
+        uri: "/tests-bundle.js?should-take-a-bit-to-parse=1&" + (new Array(300)).join("cachebreaker=" + Math.random().toFixed(5) + "&")
     }, function (err, resp, body) {
         assert.ok(err instanceof Error, "should return error")
         assert.equal(resp.statusCode, 0)


### PR DESCRIPTION
1. allow empty headers object for XDR instead of throwing (empty object means no headers too)
2. support manual timeout in IE9 with abort
3. stabilize test for timeout (now it times out repetably)