### PR TITLE
somewhat more detailed error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function createXHR(options, callback) {
     function errorFunc(evt) {
         clearTimeout(timeoutTimer)
         if(!(evt instanceof Error)){
-            evt = new Error("" + (evt || "unknown") )
+            evt = new Error("" + (evt || "Unknown XMLHttpRequest Error") )
         }
         evt.statusCode = 0
         callback(evt, failureResponse)
@@ -153,7 +153,7 @@ function createXHR(options, callback) {
         timeoutTimer = setTimeout(function(){
             aborted=true//IE9 may still call readystatechange
             xhr.abort("timeout")
-            errorFunc();
+            errorFunc(new Error("XMLHttpRequest timeout"));
         }, options.timeout )
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,7 @@ test("[func] Times out to an error ", function (assert) {
         uri: "/tests-bundle.js?should-take-a-bit-to-parse=1&" + (new Array(300)).join("cachebreaker=" + Math.random().toFixed(5) + "&")
     }, function (err, resp, body) {
         assert.ok(err instanceof Error, "should return error")
+        assert.equal(err.message, "XMLHttpRequest timeout")
         assert.equal(resp.statusCode, 0)
         assert.end()
     })
@@ -110,7 +111,7 @@ test("XDR usage (run on IE8 or 9)", function (assert) {
 test("handles errorFunc call with no arguments provided", function (assert) {
     var req = xhr({}, function (err) {
         assert.ok(err instanceof Error, "callback should get an error")
-        assert.equal(err.message, "unknown", "error message should say 'unknown'")
+        assert.equal(err.message, "Unknown XMLHttpRequest Error", "error message incorrect")
     })
     assert.doesNotThrow(function () {
         req.onerror()


### PR DESCRIPTION
With `2.0.3` I started seeing a lot of `unknown` in my error logs - that's not good, as it's really tricky to filter these errors out, so I changed the messages to, um, include more words :)

Speaking of `2.0.3` - how come npm has it, but the master here is still `2.0.1`?