### PR TITLE
Add post, del, put, etc. convenience methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ xhr({
 ```
 
 ## `var req = xhr(options, callback)`
+Using this invocation, `options` should include a `uri` property for the request.
+
+## `var req = xhr(url, callback)`
+`xhr` may also be called with a simple string instead of a set of options. In this case, a GET request will be made to that url.
+
+## `var req = xhr(url, options, callback)`
+The above may also be called with the standard set of options.
 
 ```js
 type XhrOptions = String | {
@@ -67,19 +74,14 @@ Your callback will be called once with the arguments
 Your callback will be called with an [`Error`][5] if there is an error in the browser that prevents sending the request.
 A HTTP 500 response is not going to cause an error to be returned.
 
-## Shorthands
 
-## `var req = xhr(url, callback)`
-`xhr` may also be called with a simple string instead of a set of options. In this case, a GET request will be made to that url.
-
-## `var req = xhr(url, options, callback)`
-The above shorthand may also be called with the standard set of options.
+## Method Shorthands
 
 ## `var req = xhr.{post, put, patch, del, head, get}(options, callback)`
 The `xhr` module has convience functions attached that will make requests with the given method.
 Each function is named after its method, with the exception of `DELETE` which is called `xhr.del` for compatibility.
 
-The method function shorthand may be combined with the above url shorthand for succinct and descriptive requests. For example,
+The method shorthands may be combined with the url-first form of `xhr` for succinct and descriptive requests. For example,
 
 ```js
 xhr.post('/post-to-me', function(err, resp) {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Your callback will be called once with the arguments
     headers: {},
     url: String,
     rawRequest: xhr
-}   
+}
 ```
  - `body`: HTTP response body - [`xhr.response`][6], [`xhr.responseText`][7] or
     [`xhr.responseXML`][8] depending on the request type.
@@ -62,13 +62,40 @@ Your callback will be called once with the arguments
     or [`XDomainRequest`][4] instance (if on IE8/IE9 &&
     `options.useXDR` is set to `true`)
  - `headers`: A collection of headers where keys are header names converted to lowercase
-    
 
-Your callback will be called with an [`Error`][5] if there is an error in the browser that prevents sending the request. 
-A HTTP 500 response is not going to cause an error to be returned. 
-    
-If `options` is a string then it's a short hand for
-    `{ method: "GET", uri: string }`
+
+Your callback will be called with an [`Error`][5] if there is an error in the browser that prevents sending the request.
+A HTTP 500 response is not going to cause an error to be returned.
+
+## Shorthands
+
+## `var req = xhr(url, callback)`
+`xhr` may also be called with a simple string instead of a set of options. In this case, a GET request will be made to that url.
+
+## `var req = xhr(url, options, callback)`
+The above shorthand may also be called with the standard set of options.
+
+## `var req = xhr.{post, put, patch, del, head, get}(options, callback)`
+The `xhr` module has convience functions attached that will make requests with the given method.
+Each function is named after its method, with the exception of `DELETE` which is called `xhr.del` for compatibility.
+
+The method function shorthand may be combined with the above url shorthand for succinct and descriptive requests. For example,
+
+```js
+xhr.post('/post-to-me', function(err, resp) {
+  console.log(resp.body)
+})
+```
+
+or
+
+```js
+xhr.del('/delete-me', { headers: { my: 'auth' } }, function (err, resp) {
+  console.log(resp.statusCode);
+})
+```
+
+## Options
 
 ### `options.method`
 
@@ -80,7 +107,7 @@ Specify the method the [`XMLHttpRequest`][3] should be opened
 Specify whether this is a cross origin (CORS) request for IE<10.
     Switches IE to use [`XDomainRequest`][4] instead of `XMLHttpRequest`.
     Ignored in other browsers.
-    
+
 Note that headers cannot be set on an XDomainRequest instance.
 
 ### `options.sync`
@@ -121,8 +148,8 @@ Additionally the response body is parsed as JSON
 
 Specify whether user credentials are to be included in a cross-origin
     request. Sets [`xhr.withCredentials`][10]. Defaults to false.
-    
-A wildcard `*` cannot be used in the `Access-Control-Allow-Origin` header when `withCredentials` is true. 
+
+A wildcard `*` cannot be used in the `Access-Control-Allow-Origin` header when `withCredentials` is true.
     The header needs to specify your origin explicitly or browser will abort the request.
 
 ### `options.responseType`

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ createXHR.XDomainRequest = "withCredentials" in (new createXHR.XMLHttpRequest())
 
 forEach(["get", "put", "post", "patch", "head", "delete"], function(method) {
     createXHR[method === "delete" ? "del" : method] = function(uri, options, callback) {
-        var options = initParams(uri, options, callback)
+        options = initParams(uri, options, callback)
         options.method = method.toUpperCase()
         return _createXHR(options)
     }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
+    "for-each": "~0.3.2",
     "global": "~4.3.0",
     "once": "~1.1.1",
-    "parse-headers": "^2.0.0"
+    "parse-headers": "^2.0.0",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "pre-commit": "1.0.10",

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 var window = require("global/window")
 var test = require("tape")
+var forEach = require("for-each")
 
 var xhr = require("../index.js")
 
@@ -126,6 +127,106 @@ test("constructs and calls callback without throwing", function (assert) {
         xhr({})
     }, "callback is not optional")
     assert.end()
+})
+
+test("[func] xhr[method] get, put, post, patch", function (assert) {
+  var i = 0
+  methods = ["get", "put", "post", "patch"]
+  forEach(methods, function (method) {
+      xhr[method]({
+          uri: "https://httpbin.org/" + method
+      }, function (err, resp, body) {
+          i++
+          assert.ifError(err, "no err")
+          assert.equal(resp.statusCode, 200)
+          assert.equal(resp.method, method.toUpperCase())
+          assert.notEqual(resp.body.length, 0)
+
+          if (i === methods.length) assert.end()
+      })
+  })
+})
+
+test("xhr[method] get, put, post, patch with url shorthands", function (assert) {
+  var i = 0
+  methods = ["get", "put", "post", "patch"]
+  forEach(methods, function (method) {
+      xhr[method]("/some-test", function (err, resp, body) {
+          i++
+          assert.equal(resp.method, method.toUpperCase())
+
+          if (i === methods.length) assert.end()
+      })
+  })
+})
+
+test("xhr[method] get, put, post, patch with url shorthands and options", function (assert) {
+  var i = 0
+  methods = ["get", "put", "post", "patch"]
+  forEach(methods, function (method) {
+      xhr[method]("/some-test", { headers: { foo: 'bar' } }, function (err, resp, body) {
+          i++
+          assert.equal(resp.rawRequest.headers.foo, 'bar')
+          assert.equal(resp.method, method.toUpperCase())
+
+          if (i === methods.length) assert.end()
+      })
+  })
+})
+
+test("[func] xhr.head", function (assert) {
+    xhr.head({
+        uri: "https://httpbin.org/get",
+    }, function (err, resp, body) {
+        assert.ifError(err, "no err")
+        assert.equal(resp.statusCode, 200)
+        assert.equal(resp.method, "HEAD")
+        assert.notOk(resp.body)
+        assert.end()
+    })
+})
+
+test("xhr.head url shorthand", function (assert) {
+    xhr.head("https://httpbin.org/get", function (err, resp, body) {
+        assert.equal(resp.method, "HEAD")
+        assert.end()
+    })
+})
+
+test("[func] xhr.del", function (assert) {
+    xhr.del({
+        uri: "https://httpbin.org/delete"
+    }, function (err, resp, body) {
+        assert.ifError(err, "no err")
+        assert.equal(resp.statusCode, 200)
+        assert.equal(resp.method, "DELETE")
+        assert.notEqual(resp.body.length, 0)
+        assert.end()
+    })
+})
+
+test("xhr.del url shorthand", function (assert) {
+    xhr.del("https://httpbin.org/delete", function (err, resp, body) {
+        assert.equal(resp.method, "DELETE")
+        assert.end()
+    })
+})
+
+test("url signature without object", function (assert) {
+    xhr("/some-test", function (err, resp, body) {
+        assert.equal(resp.url, '/some-test')
+        assert.end()
+    })
+})
+
+test("url signature with object", function (assert) {
+    xhr("/some-test", {
+        headers: { "foo": "bar" }
+    }, function (err, resp, body) {
+        assert.equal(resp.url, '/some-test')
+        assert.equal(resp.rawRequest.headers.foo, 'bar')
+        assert.end()
+    })
 })
 
 test("XHR can be overridden", function (assert) {


### PR DESCRIPTION
This implements the convenience methods discused in #96. The tests depend on the [httpbin](https://httpbin.org/) external service and uses XDR for the cross-domain requests.

Open to feedback.