### PR TITLE
Don’t read responseXML if response has no content

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,9 @@ function _createXHR(options) {
         if (xhr.response) {
             body = xhr.response
         } else if (xhr.responseType === "text" || !xhr.responseType) {
-            body = xhr.responseText || xhr.responseXML
+            body = xhr.responseText || null
+        } else {
+            xhr.responseXML
         }
 
         if (isJson) {


### PR DESCRIPTION
Firefox will return the error "XML Parsing Error: no element found" if you try to read `responseXML` on a response that has no content, e.g. a 204 response.

The issue is described here:

https://bugzilla.mozilla.org/show_bug.cgi?id=547718

This PR prevents this library from returning that error, as I would prefer the null response instead.