### PR TITLE
Use SPDX license expression in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,7 @@
     "tap-spec": "^4.0.2",
     "tape": "^4.0.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/Raynos/xhr/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "run-browser test/index.js -b | tap-spec",
     "browser": "run-browser test/index.js"


### PR DESCRIPTION
Thanks so much for xhr! I use it in several projects!

This tiny PR changes the current `package.json` property `licenses` to a `license` property with just the string `"MIT"`. This is the [machine-readable way](https://spdx.org/licenses/) to add license metadata, and also [what npm recommends](https://docs.npmjs.com/files/package.json#license). The Ruby-style license array is equally well structured, but we've landed on the string license expression approach for npm.

Best,

K