### PR TITLE
object body needs serialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,10 @@ function _createXHR(options) {
         callback(evt, failureResponse)
     }
 
+    function serialize_params(obj) {
+        return Object.keys(obj).map( k => encodeURIComponent(k) + '=' + encodeURIComponent(obj[k]) ).join('&')
+    }
+
     // will load the data & process the response in a special response object
     function loadFunc() {
         if (aborted) return
@@ -161,6 +165,8 @@ function _createXHR(options) {
             headers["content-type"] || headers["Content-Type"] || (headers["Content-Type"] = "application/json") //Don't override existing accept header declared by user
             body = JSON.stringify(options.json)
         }
+    } else if (body !== null && typeof body === 'object') {
+        body = serialize_params(body)
     }
 
     xhr.onreadystatechange = readystatechange

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function _createXHR(options) {
     }
 
     function serialize_params(obj) {
-        return Object.keys(obj).map( k => encodeURIComponent(k) + '=' + encodeURIComponent(obj[k]) ).join('&')
+        return Object.keys(obj).map( function(k) { return encodeURIComponent(k) + '=' + encodeURIComponent(obj[k]) } ).join('&')
     }
 
     // will load the data & process the response in a special response object


### PR DESCRIPTION
When body has an object data, it needs to be serialized in order to work.
This simple solution works and doesn't requires additional libraries or dependencies.