### PR TITLE
A failing test in Firefox when the server returns 204

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "test": "run-browser test/index.js -b | tap-spec",
-    "browser": "run-browser test/index.js"
+    "test": "node test-server.js phantom | tap-spec",
+    "browser": "node test-server.js"
   }
 }

--- a/test-server.js
+++ b/test-server.js
@@ -1,0 +1,29 @@
+var http = require('http')
+var runBrowser = require('run-browser')
+
+var phantom = process.argv[2] === 'phantom'
+var port = 3000
+
+var handler = runBrowser.createHandler('test/index.js', null, phantom)
+var server = http.createServer(function (req, res) {
+    if (req.url === '/no-content') {
+        res.statusCode = 204
+        res.end('')
+    } else if (req.url === '/timeout') {
+        setTimeout(function() {
+            res.statusCode = 200
+            res.end()
+        }, 5000)
+    } else {
+        return handler(req, res, phantom)
+    }
+})
+server.listen(port)
+
+if (phantom) {
+    var proc = runBrowser.runPhantom('http://localhost:' + port+ '/')
+    proc.stdout.pipe(process.stdout)
+    proc.stderr.pipe(process.stderr)
+} else {
+    console.log('Open a browser and navigate to "http://localhost:' + port+ '"')
+}

--- a/test/index.js
+++ b/test/index.js
@@ -42,10 +42,20 @@ test("[func] Returns http error responses like npm's request (cross-domain)", fu
     }
 })
 
+test("[func] Returns a falsey body for 204 responses", function(assert) {
+    xhr({
+        uri: "/no-content"
+    }, function(err, resp, body) {
+        assert.notOk(body, "body should be falsey")
+        assert.equal(resp.statusCode, 204)
+        assert.end()
+    })
+})
+
 test("[func] Times out to an error ", function(assert) {
     xhr({
         timeout: 1,
-        uri: "/tests-bundle.js?should-take-a-bit-to-parse=1&" + (new Array(300)).join("cachebreaker=" + Math.random().toFixed(5) + "&")
+        uri: "/timeout"
     }, function(err, resp, body) {
         assert.ok(err instanceof Error, "should return error")
         assert.equal(err.message, "XMLHttpRequest timeout")


### PR DESCRIPTION
I created a new test server that was capable of returning 204s in order to pull off the test.

I also switched the "this should probably take a while" request to use another custom endpoint, since sometimes the response was actually coming back quick enough for the test to fail.

Failing test for #111