### PR TITLE
"xhr" -> "XMLHttpRequest" where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xhr
 
-A small xhr wrapper. Designed for use with [browserify](http://browserify.org/).
+A small XMLHttpRequest wrapper. Designed for use with [browserify](http://browserify.org/).
 
 Browser support: IE8+ and everything else.
 
@@ -57,8 +57,8 @@ Your callback will be called once with the arguments
     rawRequest: xhr
 }
 ```
- - `body`: HTTP response body - [`xhr.response`][6], [`xhr.responseText`][7] or
-    [`xhr.responseXML`][8] depending on the request type.
+ - `body`: HTTP response body - [`XMLHttpRequest.response`][6], [`XMLHttpRequest.responseText`][7] or
+    [`XMLHttpRequest.responseXML`][8] depending on the request type.
  - `rawRequest`: Original  [`XMLHttpRequest`][3] instance
     or [`XDomainRequest`][4] instance (if on IE8/IE9 &&
     `options.useXDR` is set to `true`)
@@ -105,7 +105,7 @@ xhr.del('/delete-me', { headers: { my: 'auth' } }, function (err, resp) {
 ### `options.method`
 
 Specify the method the [`XMLHttpRequest`][3] should be opened
-    with. Passed to [`xhr.open`][2]. Defaults to "GET"
+    with. Passed to [`XMLHttpRequest.open`][2]. Defaults to "GET"
 
 ### `options.useXDR`
 
@@ -126,16 +126,16 @@ Specify whether this is a synchrounous request. Note that when
 
 Pass in body to be send across the [`XMLHttpRequest`][3].
     Generally should be a string. But anything that's valid as
-    a parameter to [`xhr.send`][1] should work
+    a parameter to [`XMLHttpRequest.send`][1] should work
 
 ### `options.uri` or `options.url`
 
-The uri to send a request to. Passed to [`xhr.open`][2]. `options.url` and `options.uri` are aliases for each other.
+The uri to send a request to. Passed to [`XMLHttpRequest.open`][2]. `options.url` and `options.uri` are aliases for each other.
 
 ### `options.headers`
 
 An object of headers that should be set on the request. The
-    key, value pair is passed to [`xhr.setRequestHeader`][9]
+    key, value pair is passed to [`XMLHttpRequest.setRequestHeader`][9]
 
 ### `options.timeout`
 
@@ -152,14 +152,14 @@ Additionally the response body is parsed as JSON
 ### `options.withCredentials`
 
 Specify whether user credentials are to be included in a cross-origin
-    request. Sets [`xhr.withCredentials`][10]. Defaults to false.
+    request. Sets [`XMLHttpRequest.withCredentials`][10]. Defaults to false.
 
 A wildcard `*` cannot be used in the `Access-Control-Allow-Origin` header when `withCredentials` is true.
     The header needs to specify your origin explicitly or browser will abort the request.
 
 ### `options.responseType`
 
-Determines the data type of the `response`. Sets [`xhr.responseType`][11]. For example, a `responseType` of `document` will return a parsed `Document` object as the `response.body` for an XML resource.
+Determines the data type of the `response`. Sets [`XMLHttpRequest.responseType`][11]. For example, a `responseType` of `document` will return a parsed `Document` object as the `response.body` for an XML resource.
 
 ### `options.beforeSend`
 


### PR DESCRIPTION
Changed references to `xhr` to `XMLHttpRequest` where they were referencing the web API instead of this module.