### PR TITLE
Fixed responseXML for correct responseType

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,9 @@ function _createXHR(options) {
         if (xhr.response) {
             body = xhr.response
         } else if (xhr.responseType === "text" || !xhr.responseType) {
-            body = xhr.responseText || xhr.responseXML
+            // responseXML is only accessible if the object's 'responseType' is '' or 'document'
+            if(xhr.responseType === "") body = xhr.responseText || xhr.responseXML;
+            else body = xhr.responseText;
         }
 
         if (isJson) {


### PR DESCRIPTION
According to https://xhr.spec.whatwg.org/#the-responsexml-attribute the `responseXML` attribute is only available when responseType is an empty string or `"document"`. Here's a fix for that.